### PR TITLE
LWPCookieJar expects rest to be a dict

### DIFF
--- a/cookies.py
+++ b/cookies.py
@@ -24,7 +24,7 @@ def makeCookie(name, value):
         discard=False,
         comment=None,
         comment_url=None,
-        rest=None
+        rest={}
     )
 
 # Create a cookie jar to store our custom cookies.


### PR DESCRIPTION
At least LWPCookieJar expects rest to be a dictionary.
(Thanks for the copy-pasteable example :smile: )

```
/usr/lib/python2.7/_LWPCookieJar.pyc in save(self, filename, ignore_discard, ignore_expires)
     87             # port_spec) while still being compatible with libwww-perl, I hope.
     88             f.write("#LWP-Cookies-2.0\n")
---> 89             f.write(self.as_lwp_str(ignore_discard, ignore_expires))
     90         finally:
     91             f.close()

/usr/lib/python2.7/_LWPCookieJar.pyc in as_lwp_str(self, ignore_discard, ignore_expires)
     73             if not ignore_expires and cookie.is_expired(now):
     74                 continue
---> 75             r.append("Set-Cookie3: %s" % lwp_cookie_str(cookie))
     76         return "\n".join(r+[""])
     77 

/usr/lib/python2.7/_LWPCookieJar.pyc in lwp_cookie_str(cookie)
     38     if cookie.comment_url: h.append(("commenturl", cookie.comment_url))
     39 
---> 40     keys = cookie._rest.keys()
     41     keys.sort()
     42     for k in keys:

AttributeError: 'NoneType' object has no attribute 'keys'
```
